### PR TITLE
Stop a space in the rSubsection for tighter right-alignment

### DIFF
--- a/resume.cls
+++ b/resume.cls
@@ -98,10 +98,10 @@
   %%    Employer (bold)                     Dates (regular)    %%
   %%    Title (emphasis)                Location (emphasis)    %%
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  {\bf #1}                 \hfill                  {    #2}
+  {\bf #1}                 \hfill                  {    #2}% Stop a space
   \ifthenelse{\equal{#3}{}}{}{
   \\
-  {\em #3}                 \hfill                  {\em #4}
+  {\em #3}                 \hfill                  {\em #4}% Stop a space
   }\smallskip
   % \cdot used for bullets, items non-indented
   \begin{list}{$\cdot$}{\leftmargin=0em}


### PR DESCRIPTION
Add `%` after `{   #2}` and `{\em   #4}` in the `rSubsection` environment for better right alignment of Dates and Location.
